### PR TITLE
Enable NVIDIA VAAPI hardware transcoding for Jellyfin

### DIFF
--- a/hosts/homelab/configuration.nix
+++ b/hosts/homelab/configuration.nix
@@ -14,9 +14,12 @@
     '';
   };
 
-  # Enable OpenGL
+  # Enable OpenGL and NVIDIA VAAPI for hardware-accelerated transcoding
   hardware.graphics = {
     enable = true;
+    extraPackages = with pkgs; [
+      nvidia-vaapi-driver
+    ];
   };
 
   # Load nvidia driver for Xorg and Wayland

--- a/modules/homelab/jellyfin.nix
+++ b/modules/homelab/jellyfin.nix
@@ -18,6 +18,15 @@ in {
     };
   };
 
+  # Grant the media user access to GPU devices for hardware transcoding
+  users.users.media.extraGroups = ["video" "render"];
+
+  # Set VAAPI driver for Jellyfin's FFmpeg
+  systemd.services.jellyfin.environment = {
+    LIBVA_DRIVER_NAME = "nvidia";
+    NVD_BACKEND = "direct";
+  };
+
   services.jellyfin = {
     enable = true;
     openFirewall = true;


### PR DESCRIPTION
## Summary
This PR adds NVIDIA GPU hardware transcoding support to Jellyfin by configuring VAAPI drivers and granting the media user access to GPU devices.

## Key Changes
- Added `nvidia-vaapi-driver` to system graphics packages for hardware-accelerated video encoding/decoding
- Granted the `media` user access to `video` and `render` groups to enable GPU device access
- Configured Jellyfin's FFmpeg environment variables to use NVIDIA's VAAPI driver (`LIBVA_DRIVER_NAME=nvidia`) and direct backend mode (`NVD_BACKEND=direct`)

## Implementation Details
The changes enable Jellyfin to leverage NVIDIA GPU capabilities for transcoding operations, which reduces CPU load and improves performance when handling multiple concurrent streams. The media user now has the necessary permissions to access GPU devices, and FFmpeg is explicitly configured to use the NVIDIA VAAPI driver for hardware acceleration.

https://claude.ai/code/session_01HYC2ezqw5oDGjwe9gJNxNb