### PR TITLE
nix-on-droid: proof-of-concept Android (phone) config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
         ./devshell.nix
         ./docs.nix
         ./hosts
+        ./nix-on-droid
         ./overlays
       ];
       systems = [
@@ -37,6 +38,13 @@
 
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     nixos-wsl.inputs.nixpkgs.follows = "nixpkgs";
+
+    # Nix (package manager + home-manager) running on Android in a Termux-like
+    # userspace. NOT NixOS — see nix-on-droid/README.md. No release branch tracks
+    # nixpkgs 26.05 yet, so we follow master (pinned via flake.lock).
+    nix-on-droid.url = "github:nix-community/nix-on-droid";
+    nix-on-droid.inputs.nixpkgs.follows = "nixpkgs";
+    nix-on-droid.inputs.home-manager.follows = "home-manager";
 
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix-on-droid/README.md
+++ b/nix-on-droid/README.md
@@ -1,0 +1,93 @@
+# nix-on-droid (Nix on Android) — proof of concept
+
+This directory is a **proof of concept** for running parts of this configuration
+on Android via [nix-on-droid](https://github.com/nix-community/nix-on-droid).
+
+## What this is (and isn't)
+
+nix-on-droid is a Termux-like Android app that runs the **Nix package manager**
+and **home-manager** in an Android userspace (via proot). It is **not** NixOS:
+
+- No systemd, no NixOS module layer, no `niri`/desktop, no homelab services.
+- The `fireproof.*` modules in `modules/` are **NixOS** modules and cannot be
+  imported here, so the phone config (`phone/default.nix`) is **self-contained**:
+  a curated list of portable CLI tools plus a small home-manager config.
+
+For *real* NixOS on a phone (replacing Android, requires a supported device +
+flashing) see [mobile-nixos](https://github.com/NixOS/mobile-nixos) — out of
+scope for this PoC.
+
+## Layout
+
+- `default.nix` — flake-parts module exposing `nixOnDroidConfigurations.phone`.
+  Builds directly against `nixpkgs.legacyPackages.aarch64-linux` so we don't add
+  `aarch64-linux` to the flake's top-level `systems`.
+- `phone/default.nix` — the self-contained device config (packages + home-manager
+  + an inert agenix secrets scaffold).
+
+## Building / deploying
+
+Unlike the NixOS hosts, there is **no ISO and no remote deploy**. You install
+the app and activate on the device itself:
+
+1. Install the nix-on-droid APK (F-Droid or the GitHub releases).
+2. Get this flake onto the phone (clone it, or `nix-on-droid switch` against the
+   remote flake URL).
+3. On the phone:
+   ```sh
+   nix-on-droid switch --flake .#phone
+   ```
+   Builds run natively on aarch64 (or substitute from a binary cache).
+
+> **Note:** This PoC adds the `nix-on-droid` flake **input** but the `flake.lock`
+> was **not** updated in the branch (the CI sandbox that authored it has no `nix`
+> binary). Run `nix flake lock` (or `just update`) once locally before building,
+> otherwise evaluation will fail on the missing lock entry.
+
+## Secrets (agenix) — optional, manual
+
+The rest of this flake uses **system-level** agenix. nix-on-droid has no NixOS
+layer, so the phone uses the **home-manager** agenix modules instead
+(`inputs.agenix.homeManagerModules.default` +
+`inputs.agenix-rekey.homeManagerModules.default`). The wiring lives in
+`phone/default.nix` but is **disabled** until the phone's public key exists, so
+the PoC builds as a pure CLI environment out of the box.
+
+To turn it on:
+
+1. **Generate an identity on the phone** (inside nix-on-droid):
+   ```sh
+   ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
+   ```
+   The **private** key stays on the device — it becomes the agenix decryption
+   identity (`age.identityPaths`). Never commit it.
+2. **Register the public key** as a recipient:
+   ```sh
+   cp id_ed25519.pub secrets/hosts/phone/id_ed25519.pub   # from the phone to the repo
+   ```
+   This flips the `builtins.pathExists` guard and activates the agenix block.
+3. **Rekey on your desktop with the YubiKey** (the master identity):
+   ```sh
+   just secret-rekey
+   ```
+   This re-encrypts the selected secrets so the phone's key can decrypt them.
+4. Re-run `nix-on-droid switch --flake .#phone` on the phone.
+
+### Making `just secret-rekey` aware of the phone
+
+`agenix-rekey` auto-discovers `nixosConfigurations` (and home-manager nested in
+them) plus standalone `homeConfigurations`. It does **not** scan
+`nixOnDroidConfigurations`. To include the phone in rekeying, expose its
+home-manager config to agenix-rekey — e.g. add a `homeConfigurations.phone`
+output or set `perSystem.agenix-rekey.homeConfigurations.phone` to the phone's
+home-manager configuration (the attr needs a `config.age`). This step is left
+out of the PoC because it only matters once you have the YubiKey + on-device key
+to actually rekey.
+
+### Security note
+
+A phone is a higher-loss-risk device than your desktops/servers. Every secret
+you rekey to it is decryptable by anyone who extracts the on-device private key,
+so **rekey only a deliberately chosen allowlist** of user-level secrets — never
+the host/server set. And never reference a plaintext private key from any Nix
+config: it would be copied into the world-readable Nix store.

--- a/nix-on-droid/default.nix
+++ b/nix-on-droid/default.nix
@@ -1,0 +1,30 @@
+# Proof-of-concept nix-on-droid (Nix on Android) integration.
+#
+# Unlike `hosts/`, these are NOT NixOS systems. nix-on-droid runs the Nix
+# package manager + home-manager in an Android userspace (Termux-like, via
+# proot) — there is no systemd and no NixOS module layer, so the `fireproof.*`
+# modules in `modules/` cannot be imported here. Each device config is therefore
+# self-contained. See ./README.md for setup and the secrets workflow.
+#
+# We build directly against `nixpkgs.legacyPackages.aarch64-linux` rather than
+# going through flake-parts' `withSystem`, so we don't have to add
+# `aarch64-linux` to the top-level `systems` (which would needlessly expand
+# every perSystem output — devShells, formatter, docs — to aarch64).
+{inputs, ...}: let
+  inherit (inputs.nixpkgs) lib;
+  fpLib = import ../lib {inherit lib;};
+
+  system = "aarch64-linux";
+
+  mkDroid = host:
+    inputs.nix-on-droid.lib.nixOnDroidConfiguration {
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
+      home-manager-path = inputs.home-manager.outPath;
+      extraSpecialArgs = {inherit inputs fpLib;};
+      modules = [host];
+    };
+in {
+  config.flake.nixOnDroidConfigurations = {
+    phone = mkDroid ./phone;
+  };
+}

--- a/nix-on-droid/phone/default.nix
+++ b/nix-on-droid/phone/default.nix
@@ -1,0 +1,159 @@
+# Self-contained nix-on-droid config for a phone.
+#
+# This is a proof of concept. It deliberately does NOT import anything from
+# `modules/` — those are NixOS modules wired into the `fireproof.*` option tree
+# (systemd, users.users, system-level agenix) and cannot evaluate under
+# nix-on-droid. Instead we hand-pick a small set of portable CLI tools and a
+# lightweight home-manager config, mirroring a subset of `modules/programs/`.
+#
+# Secrets (agenix) are scaffolded but INERT until you add the phone's public key
+# at `secrets/hosts/phone/id_ed25519.pub` and rekey on your desktop with the
+# YubiKey. See ../README.md for the full workflow.
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}: let
+  # The phone is treated as a rekey recipient, like the hosts under
+  # `secrets/hosts/`. Until you generate a key on-device and drop its public
+  # half here, the whole agenix block stays disabled so the PoC builds as a pure
+  # CLI environment.
+  phonePubkey = ../../secrets/hosts/phone/id_ed25519.pub;
+  secretsEnabled = builtins.pathExists phonePubkey;
+
+  # Where nix-on-droid puts the user home. The on-device private key (generated
+  # with `ssh-keygen` inside the app) lives here and is used as the agenix
+  # decryption identity. Never commit this private key.
+  droidHome = "/data/data/com.termux.nix/files/home";
+in {
+  # Curated portable CLI packages (cf. modules/programs/core.nix).
+  environment.packages = with pkgs; [
+    # shell + navigation
+    fish
+    starship
+    zoxide
+    fzf
+    # editors
+    neovim
+    # version control
+    git
+    gh
+    delta
+    # modern CLI replacements
+    bat
+    fd
+    ripgrep
+    eza
+    # data wrangling / misc
+    jq
+    tree
+    htop
+    curl
+    wget
+    rsync
+    unzip
+    openssh
+  ];
+
+  # Back up clobbered /etc files instead of failing activation.
+  environment.etcBackupExtension = ".bak";
+
+  # Read the nix-on-droid changelog before bumping this.
+  system.stateVersion = "24.05";
+
+  # Flakes, so `nix-on-droid switch --flake .#phone` works on-device.
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
+
+  user.shell = "${pkgs.fish}/bin/fish";
+
+  home-manager = {
+    useGlobalPkgs = true;
+    backupFileExtension = "hm-bak";
+    # Make `inputs` available to the HM config (used for the agenix modules).
+    extraSpecialArgs = {inherit inputs;};
+
+    config = {
+      config,
+      lib,
+      pkgs,
+      inputs,
+      ...
+    }:
+      {
+        home.stateVersion = "24.05";
+
+        programs.fish.enable = true;
+
+        programs.starship.enable = true;
+
+        programs.zoxide.enable = true;
+
+        programs.fzf.enable = true;
+
+        programs.bat.enable = true;
+
+        programs.neovim = {
+          enable = true;
+          defaultEditor = true;
+          viAlias = true;
+          vimAlias = true;
+        };
+
+        programs.git = {
+          enable = true;
+          settings = {
+            user.email = "nickolaj@fireproof.website";
+            user.name = "Nickolaj Jepsen";
+            init.defaultBranch = "main";
+            push.autosetupremote = "true";
+            pull.rebase = "true";
+          };
+        };
+
+        programs.gh = {
+          enable = true;
+          settings.git_protocol = "ssh";
+        };
+      }
+      # --- agenix secrets scaffold (inert until the phone pubkey exists) -------
+      // lib.optionalAttrs secretsEnabled {
+        imports = [
+          inputs.agenix.homeManagerModules.default
+          inputs.agenix-rekey.homeManagerModules.default
+        ];
+
+        # Decryption identity: the key you generate ON THE PHONE. agenix uses it
+        # at activation to decrypt the rekeyed secrets below.
+        age.identityPaths = ["${droidHome}/.ssh/id_ed25519"];
+
+        age.rekey = {
+          storageMode = "local";
+          hostPubkey = builtins.readFile phonePubkey;
+          # Same master key as the rest of the flake (modules/base/secrets.nix):
+          # rekeying still happens on your desktop with the YubiKey.
+          masterIdentities = [
+            {
+              identity = ../../secrets/yubikey-identity.pub;
+            }
+          ];
+          extraEncryptionPubkeys = [
+            "age1pzrfw28f8qvsk9g8p2stundf4ph466jut0g6q47sse76zljtqy9q2w32zr" # Backup key (bitwarden)
+          ];
+          localStorageDir = ../../secrets/hosts/phone/.rekey;
+          generatedSecretsDir = ../../secrets/hosts/phone;
+        };
+
+        # Example user-level secret to prove the path end to end. Add more as
+        # needed, then rerun the rekey workflow from ../README.md.
+        age.secrets.ssh-key-ao = {
+          rekeyFile = ../../secrets/ssh-key-ao.age;
+          path = "${droidHome}/.ssh/id_ao";
+          mode = "0600";
+        };
+      };
+  };
+}

--- a/secrets/hosts/phone/README.md
+++ b/secrets/hosts/phone/README.md
@@ -1,0 +1,21 @@
+# `phone` recipient (nix-on-droid)
+
+This directory holds the **public** key that identifies the phone as an
+agenix-rekey recipient — exactly like the other `secrets/hosts/<host>/`
+directories, except the phone's key is generated **on the device**, not baked
+into a bootstrap ISO.
+
+It is intentionally empty (this README aside) until you complete the on-device
+setup. The nix-on-droid secrets scaffold in
+`nix-on-droid/phone/default.nix` stays disabled (`builtins.pathExists` guard)
+while `id_ed25519.pub` is missing, so the flake keeps evaluating.
+
+To enable secrets, follow the workflow in `nix-on-droid/README.md`:
+
+1. On the phone (inside the nix-on-droid app): `ssh-keygen -t ed25519`
+2. Copy the **public** half here as `id_ed25519.pub` (never the private key).
+3. Run `just secret-rekey` on your desktop with the YubiKey present.
+
+The private key stays on the phone and is referenced as the agenix decryption
+identity (`age.identityPaths`). Do **not** commit it — putting a plaintext key
+anywhere a Nix config reads it would copy it into the world-readable Nix store.


### PR DESCRIPTION
## What

A **proof of concept** for running parts of this flake on Android, from a terminal emulator, via [nix-on-droid](https://github.com/nix-community/nix-on-droid) (a Termux-like app running the Nix package manager + home-manager in Android userspace).

This is **not** NixOS on a phone — there's no systemd / NixOS module layer, so the `fireproof.*` modules can't be imported. The phone config is therefore **self-contained**.

## Changes

- **`flake.nix`** — add the `nix-on-droid` input (follows `nixpkgs` + `home-manager`) and import the new `./nix-on-droid` flake-parts module.
- **`nix-on-droid/default.nix`** — expose `nixOnDroidConfigurations.phone`, built directly against `nixpkgs.legacyPackages.aarch64-linux` so the top-level `systems` list is left untouched (avoids needlessly expanding every perSystem output to aarch64).
- **`nix-on-droid/phone/default.nix`** — curated portable CLI tools (fish, neovim, git/gh, ripgrep, fd, bat, fzf, zoxide, …) + a lightweight home-manager config. Mirrors a subset of `modules/programs/` rather than importing it.
- **agenix secrets** — scaffolded via the *home-manager* agenix modules (the rest of the repo uses the *system* ones), kept **inert** behind a `builtins.pathExists` guard on `secrets/hosts/phone/id_ed25519.pub`. The PoC builds as a pure CLI environment until the phone's pubkey is added and rekeyed with the YubiKey.
- **READMEs** — `nix-on-droid/README.md` (deploy model, manual secrets/rekey workflow, security caveats) and `secrets/hosts/phone/README.md` (recipient placeholder).

## Deploy model

Unlike the NixOS hosts (ISO bake + `bootstrap-install`), nix-on-droid activates **on-device**:

```sh
nix-on-droid switch --flake .#phone
```

## Secrets

The phone becomes a rekey recipient like the other `secrets/hosts/<host>/` entries, except its key is generated **on-device** (out of band — same chicken-and-egg the ISO bake solves for NixOS). Decryption uses an on-device identity; the YubiKey is only needed on the desktop to `just secret-rekey`. Full steps are in `nix-on-droid/README.md`.

> agenix-rekey auto-discovers `nixosConfigurations` / `homeConfigurations` but **not** `nixOnDroidConfigurations`; registering the phone for rekeying is documented as a follow-up since it only matters once a real pubkey + YubiKey are available.

## ⚠️ Before building

`flake.lock` was **not** updated — the environment that authored this branch has no `nix` binary. Run `nix flake lock` (or `just update`) locally before building, otherwise evaluation fails on the missing lock entry. I also couldn't `just fmt` / `just build-system` here for the same reason, so this hasn't been build-verified.

## Out of scope (follow-ups)

- Actual on-device install + YubiKey rekey (user-only steps).
- Extracting shared home-manager modules for real reuse (kept self-contained per scoping).
- mobile-nixos / full NixOS-on-phone.

https://claude.ai/code/session_01VyRuBrXvnHruDaMDTrYnVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyRuBrXvnHruDaMDTrYnVW)_