### PR TITLE
chore(claude): update claude-code to 2.1.169

### DIFF
--- a/overlays/claude-code.nix
+++ b/overlays/claude-code.nix
@@ -11,10 +11,10 @@
   in {
     overlayAttrs = {
       claude-code = pkgsUnstable.claude-code.overrideAttrs (oldAttrs: rec {
-        version = "2.1.167";
+        version = "2.1.169";
         src = pkgsUnstable.fetchurl {
           url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/linux-x64/claude";
-          sha256 = "d6d2995bfca3f8539d9e9aa513ff43c3daa0d556d6d1af07c6df681e050e522c";
+          sha256 = "cf066bf360cbf7b51abeb8cb230012fc0f2fed4253b2ce305de48ccd6d49a39c";
         };
         nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [pkgs.makeWrapper];
         postInstall =


### PR DESCRIPTION
## Summary
- Bump pinned claude-code from 2.1.167 to 2.1.169 in `overlays/claude-code.nix`

## Test plan
- [x] `nix build` of the claude-code package succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)