### PR TITLE
fix(overlays): use per-platform hashes for gh-aw

### DIFF
--- a/.github/workflows/update-overlays.md
+++ b/.github/workflows/update-overlays.md
@@ -106,8 +106,13 @@ For each component, check the latest GitHub release tag:
 ### 4. GitHub Agentic Workflows (`overlays/gh-aw.nix`)
 
 - **Latest version**: Check latest release of `github/gh-aw` on GitHub
-- **New hash**: `nix-prefetch-url "https://github.com/github/gh-aw/releases/download/v<VERSION>/linux-amd64"` → SRI
-- **Update fields**: `version` (in both the attribute and the `url` string) and `sha256` (SRI format)
+- **New hashes**: each platform ships a distinct binary, so compute one hash per
+  entry in `sha256Map`. For each of `linux-amd64`, `linux-arm64`, `darwin-amd64`,
+  `darwin-arm64`, run
+  `nix-prefetch-url "https://github.com/github/gh-aw/releases/download/v<VERSION>/<platform>"`
+  → convert to SRI
+- **Update fields**: `version` (in both the attribute and the `url` string) and all
+  four `sha256Map` entries (SRI format)
 
 ## Reusing the Existing PR
 

--- a/overlays/gh-aw.nix
+++ b/overlays/gh-aw.nix
@@ -10,6 +10,13 @@ _: {
       "x86_64-darwin" = "darwin-amd64";
       "aarch64-darwin" = "darwin-arm64";
     };
+    # Each release asset is a distinct binary, so hashes are per-platform.
+    sha256Map = {
+      "linux-amd64" = "sha256-04Ri+JgMYo3nG2++AGfkvUrWYO0Zl4afTylvAgkFWfA=";
+      "linux-arm64" = "sha256-y/zQrK+Yt1taXDQJz4JEh/cTATIXbUTt9OnT9LHg9zU=";
+      "darwin-amd64" = "sha256-RDpliYXbwJ6uqhdozhxEAIA0TJOEq9hmLxVJRXGxmC4=";
+      "darwin-arm64" = "sha256-c97GolUiunXYzyoTGZ9rgcFQi3jpZcWjQV4lkWPFLIY=";
+    };
     platform = platformMap.${system};
   in {
     overlayAttrs = {
@@ -19,7 +26,7 @@ _: {
 
         src = pkgs.fetchurl {
           url = "https://github.com/github/gh-aw/releases/download/v0.79.8/${platform}";
-          sha256 = "sha256-04Ri+JgMYo3nG2++AGfkvUrWYO0Zl4afTylvAgkFWfA=";
+          sha256 = sha256Map.${platform};
         };
 
         dontUnpack = true;


### PR DESCRIPTION
The gh-aw overlay hardcoded a single sha256 for every platform, but each
release asset (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64) is a
distinct binary with its own hash. The hardcoded value only matched
linux-amd64, so the arm64 (phone) build failed with a fixed-output hash
mismatch.

Replace the single sha256 with a per-platform sha256Map and update the
update-overlays workflow doc to compute all four hashes on bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016gXjiX8wkdbETNR42Z23GK